### PR TITLE
refactor: optimize modifiers

### DIFF
--- a/src/ERC20/ERC20PermitPermissionedMint.sol
+++ b/src/ERC20/ERC20PermitPermissionedMint.sol
@@ -38,14 +38,22 @@ contract ERC20PermitPermissionedMint is ERC20Permit, ERC20Burnable, Owned {
     /* ========== MODIFIERS ========== */
 
     modifier onlyByOwnGov() {
-        require(msg.sender == timelock_address || msg.sender == owner, "Not owner or timelock");
+        _onlyByOwnGov();
         _;
     }
 
+    function _onlyByOwnGov() private view {
+        require(msg.sender == timelock_address || msg.sender == owner, "Not owner or timelock");
+    }
+
     modifier onlyMinters() {
-       require(minters[msg.sender] == true, "Only minters");
+        _onlyMinters();
         _;
-    } 
+    }
+
+    function _onlyMinters() private view {
+       require(minters[msg.sender] == true, "Only minters");
+    }
 
     /* ========== RESTRICTED FUNCTIONS ========== */
 

--- a/src/OperatorRegistry.sol
+++ b/src/OperatorRegistry.sol
@@ -20,6 +20,7 @@ pragma solidity ^0.8.0;
 // Reviewer(s) / Contributor(s)
 // Travis Moore: https://github.com/FortisFortuna
 // Dennis: https://github.com/denett
+// Carter Carlson: https://github.com/pegahcarter
 
 import "./Utils/Owned.sol";
 
@@ -43,8 +44,12 @@ contract OperatorRegistry is Owned {
     }
 
     modifier onlyByOwnGov() {
-        require(msg.sender == timelock_address || msg.sender == owner, "Not owner or timelock");
+        _onlyByOwnGov();
         _;
+    }
+
+    function _onlyByOwnGov() private view {
+        require(msg.sender == timelock_address || msg.sender == owner, "Not owner or timelock");
     }
 
     /// @notice Add a new validator

--- a/src/sfrxETH.sol
+++ b/src/sfrxETH.sol
@@ -22,6 +22,7 @@ pragma solidity ^0.8.0;
 // Dennett: https://github.com/denett
 // Travis Moore: https://github.com/FortisFortuna
 // Jamie Turley: https://github.com/jyturley
+// Carter Carlson: https://github.com/pegahcarter
 
 import { ERC20, ERC4626, xERC4626 } from "ERC4626/xERC4626.sol";
 import "openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
@@ -40,8 +41,12 @@ import "openzeppelin-contracts/contracts/security/ReentrancyGuard.sol";
 contract sfrxETH is xERC4626, ReentrancyGuard {
 
     modifier andSync {
-        if (block.timestamp >= rewardsCycleEnd) { syncRewards(); } 
+        _andSync();
         _;
+    }
+
+    function _andSync() private {
+        if (block.timestamp >= rewardsCycleEnd) { syncRewards(); }
     }
 
     /* ========== CONSTRUCTOR ========== */


### PR DESCRIPTION
For each function a modifier is attached to, the bytecode of the full modifier is added (reference [here](https://ethereum.stackexchange.com/questions/138331/modifier-vs-private-function)).  So, by adding a private/internal function call, the bytecode of the logic statements is only copied to the contract once and each modifier only references the function call.

I went ahead and turned the modifiers we've made into private func calls.  I left `onlyOwner` as-is to maintain the Synthetix code.  One thing I'm wondering- what are your thoughts of removing `Owned.sol` in favor of OZ's [Ownable2Step](https://docs.openzeppelin.com/contracts/5.x/api/access#Ownable2Step)?